### PR TITLE
Add publish_skip parameter to supress high-frequency publishing of gripper sensor data

### DIFF
--- a/pr2_gripper_sensor_controller/include/pr2_gripper_sensor_controller/pr2_gripper_sensor_controller.h
+++ b/pr2_gripper_sensor_controller/include/pr2_gripper_sensor_controller/pr2_gripper_sensor_controller.h
@@ -103,6 +103,7 @@ private:
   double slip_trigger;     ///< value to use as trigger for slip detection (event_detector)
   bool stable_force;       ///< flag to indicate a stable force is achieved
   int findContact_delay;   ///< counter to track how long a force is stable for
+  int publish_skip;            ///< skip count when publishing controller information
 
   // state variables about our controller
   int control_mode;        ///< the current/desired control mode we want the controller state machine to be in

--- a/pr2_gripper_sensor_controller/src/pr2_gripper_sensor_controller.cpp
+++ b/pr2_gripper_sensor_controller/src/pr2_gripper_sensor_controller.cpp
@@ -134,6 +134,8 @@ bool PR2GripperSensorController::initializeHandles(pr2_mechanism_model::RobotSta
     ROS_ERROR("PR2GripperSensorController could not find joint named '%s'", joint_name.c_str());
     return false;
   }
+
+  n.param("publish_skip", publish_skip, 1);
   
   // instantiate our gripper action object and pass it handles to our joint_state_controller and observer objects
   myGripperController = new gripperController(joint_state_, myPressureObserver, myAccelerationObserver);
@@ -413,7 +415,7 @@ void PR2GripperSensorController::update()
   //  Begin Feedback publication
 
   // publish information every nth cycle
-  if(loop_count_ % 1 == 0)
+  if(loop_count_ % publish_skip == 0)
   {
       if(controller_state_publisher_ && controller_state_publisher_->trylock())
       {
@@ -487,7 +489,7 @@ void PR2GripperSensorController::update()
   }
 
   // publish information every nth cycle
-  if(loop_count_ % 1 == 0)
+  if(loop_count_ % publish_skip == 0)
   {
     if(publish_raw_data)
     {


### PR DESCRIPTION
add ~publish_skip parameter to pr2_gripper_sensor_controller to skip publishing of sensor data.

cc: @h-kamada
