### PR TITLE
add namespaces to avoid warning

### DIFF
--- a/pr2_gripper_sensor_controller/launch/pr2_gripper_sensor_controller.yaml
+++ b/pr2_gripper_sensor_controller/launch/pr2_gripper_sensor_controller.yaml
@@ -1,5 +1,5 @@
  l_gripper_sensor_controller:
-    type: PR2GripperSensorController
+    type: pr2_gripper_sensor_controller/PR2GripperSensorController
     joint_name: l_gripper_joint
     accelerometer_name: l_gripper_motor
     left_pressure_sensor_name: l_gripper_motorl_finger_tip
@@ -16,7 +16,7 @@
     position_servo_position_tolerance: 0.01
     position_open: 0.09
  r_gripper_sensor_controller:
-    type: PR2GripperSensorController
+    type: pr2_gripper_sensor_controller/PR2GripperSensorController
     joint_name: r_gripper_joint
     accelerometer_name: r_gripper_motor
     left_pressure_sensor_name: r_gripper_motorl_finger_tip

--- a/pr2_gripper_sensor_controller/launch/pr2_gripper_sensor_controller_left.yaml
+++ b/pr2_gripper_sensor_controller/launch/pr2_gripper_sensor_controller_left.yaml
@@ -1,5 +1,5 @@
  l_gripper_sensor_controller:
-    type: PR2GripperSensorController
+    type: pr2_gripper_sensor_controller/PR2GripperSensorController
     joint_name: l_gripper_joint
     accelerometer_name: l_gripper_motor
     left_pressure_sensor_name: l_gripper_motorl_finger_tip

--- a/pr2_gripper_sensor_controller/launch/pr2_gripper_sensor_controller_right.yaml
+++ b/pr2_gripper_sensor_controller/launch/pr2_gripper_sensor_controller_right.yaml
@@ -1,5 +1,5 @@
  r_gripper_sensor_controller:
-    type: PR2GripperSensorController
+    type: pr2_gripper_sensor_controller/PR2GripperSensorController
     joint_name: r_gripper_joint
     accelerometer_name: r_gripper_motor
     left_pressure_sensor_name: r_gripper_motorl_finger_tip


### PR DESCRIPTION
@k-okada 

resolves this marginal warning:

[ WARN] [/realtime_loop]:
The deprecated controller type PR2GripperSensorController was not found.
Using the namespaced version pr2_gripper_sensor_controller/PR2GripperSensorController instead.
Please update your configuration to use the namespaced version.